### PR TITLE
refactor: update `package.json` scripts and `next.config.js` for new …

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -13,6 +13,7 @@ const nextConfig = {
   images: {
     unoptimized: true,
   },
+  output: 'export',
   webpack: (config, {dev, isServer}) => {
 
     if (!dev) {

--- a/package.json
+++ b/package.json
@@ -5,12 +5,10 @@
   "scripts": {
     "dev": "next dev",
     "build": "next build",
-    "postbuild": "npm run export",
     "prestart": "npm run build",
-    "start": "wrangler pages dev out",
+    "start": "NODE_ENV=production pnpm run wrangler",
     "lint": "next lint",
-    "preexport": "next-sitemap",
-    "export": "next export"
+    "wrangler": "wrangler pages dev out --compatibility-date=2023-10-19"
   },
   "dependencies": {
     "@headlessui/react": "1.7.17",


### PR DESCRIPTION
…build process

Removed 'postbuild', 'preexport', 'export' scripts and modified 'start' script package.json to use 'wrangler'. This aligns with the new build pipeline that uses 'wrangler' for building and serving the application. Added 'output' property to webpack config in next.config.js to set 'export' as default output directory, matching new build process